### PR TITLE
Add pure ScaLAPACK GEP solver with PDSYNGST

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Names of available solvers are listed below. `general_scalapack` and `general_el
 - scalapack_select (standard, selecting) -- PDSYEVX
 - general_scalapack (generalized) -- reduction with PDPOTRF & PDSYGST; The solver 'A' in our papers [1,2]
 - general_scalapack_select (generalized, selecting)
+- general_scalapacknew (generalized) -- reduction with PDPOTRF & PDSYNGST
 
 ### solvers need ELPA
 - general_elpa_scalapack (generalized) -- reduction with ELPA, solve SEP with PDSYEVD; The solver 'C' in our papers [1,2]

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Names of available solvers are listed below. `general_scalapack` and `general_el
 - scalapack_select (standard, selecting) -- PDSYEVX
 - general_scalapack (generalized) -- reduction with PDPOTRF & PDSYGST; The solver 'A' in our papers [1,2]
 - general_scalapack_select (generalized, selecting)
-- general_scalapacknew_eigens (generalized) -- reduction with PDPOTRF & PDSYNGST
 
 ### solvers need ELPA
 - general_elpa_scalapack (generalized) -- reduction with ELPA, solve SEP with PDSYEVD; The solver 'C' in our papers [1,2]
@@ -77,6 +76,7 @@ Names of available solvers are listed below. `general_scalapack` and `general_el
 - eigensx (standard)
 - general_scalapack_eigensx (generalized) -- reduction with PDPOTRF & PDSYGST, solve SEP with eigen_sx; The solver 'B' in our papers [1,2]
 - general_scalapack_eigens (generalized) -- reduction with PDPOTRF & PDSYGST, solve SEP with eigen_s
+- general_scalapacknew_eigens (generalized) -- reduction with PDPOTRF & PDSYNGST
 
 ### solvers need both of ELPA and EigenExa
 - general_elpa_eigensx (generalized) -- reduction with ELPA, solve SEP with eigen_sx; The solver 'G' in our papers [1,2]

--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@ Test following commands to solve a generalized eigenvalue problem with the matri
     cd eigenkernel-*
     cp Makefile.in.gfortran.noext Makefile.in
     make
-    
-The mini-application appears as bin/eigenkernel_app. You can run the application, for example, as 
+
+The mini-application appears as bin/eigenkernel_app. You can run the application, for example, as
 
     mpirun -np 4 bin/eigenkernel_app -s general_scalapack matrix/ELSES_MATRIX_BNZ30_A.mtx matrix/ELSES_MATRIX_BNZ30_B.mtx
 
 and obtain the output files named `eigenvalues.dat`, `ipratios.dat`, `log.json`. eigenvalues.dat and ipratios.dat contain computed eigenvalues and inversed participation ratios of computed eigenvectors respectively. log.json contains execution information such as given commandline options in the JSON format.
 
-When you need eigenvectors, 
-you should specify the index range to be output by `-p` option. For example, 
- 
+When you need eigenvectors,
+you should specify the index range to be output by `-p` option. For example,
+
     mpirun -np 4 bin/eigenkernel_app -s general_scalapack -d vector/ -p 1-30 matrix/ELSES_MATRIX_BNZ30_A.mtx matrix/ELSES_MATRIX_BNZ30_B.mtx
- 
-We should note that the directory `vector/` must be created before execution. 
+
+We should note that the directory `vector/` must be created before execution.
 
 In the execution command `-s <solver>` is a mandatory option to specify the solver routine. The general_scalapack solver is, of course, a pure ScaLAPACK solver. The last two arguments are paths to input matrix files in the Matrix Market format. Note that the input matrices must be symmetric and moreover the latter one must be positive definite (only real-valued matrices are supported now).
 
@@ -98,7 +98,7 @@ You can see a help message for commandline options by `eigenkernel_app -h`.
 - `--dry-run`  Exit before starting eigensolver. Used for testing matrix read and broadcast.
 
 
-## Supported ELPA and EigenExa versions 
+## Supported ELPA and EigenExa versions
 The current master branch (v．2018) supports
 - ELPA: elpa-2018.05.001
 - EigenExa: EigenExa 2.4b

--- a/src/command_argument.f90
+++ b/src/command_argument.f90
@@ -146,6 +146,8 @@ contains
       is_solver_valid = .not. arg%is_generalized_problem
     case ('general_scalapack')
       is_solver_valid = arg%is_generalized_problem
+    case ('general_scalapacknew')
+      is_solver_valid = arg%is_generalized_problem
     case ('general_scalapack_select')
       is_solver_valid = arg%is_generalized_problem
     case ('eigensx')

--- a/src/solver_main.f90
+++ b/src/solver_main.f90
@@ -21,7 +21,7 @@ contains
 
   subroutine eigen_solver(arg, matrix_A, eigenpairs, proc, matrix_B)
     use ek_solver_lapack_m, only : eigen_solver_lapack
-    use ek_solver_scalapack_all_m, only : eigen_solver_scalapack_all, solve_with_general_scalapack
+    use ek_solver_scalapack_all_m, only : eigen_solver_scalapack_all, solve_with_general_scalapack, solve_with_general_scalapacknew
     use ek_solver_scalapack_select_m, only : eigen_solver_scalapack_select
     use ek_solver_eigenexa_m, only : setup_distributed_matrix_for_eigenexa, &
          eigen_solver_eigenexa, eigen_solver_eigenk, &
@@ -63,6 +63,8 @@ contains
            arg%n_vec, eigenpairs)
     case ('general_scalapack')
       call solve_with_general_scalapack(n, proc, matrix_A, eigenpairs, matrix_B)
+    case ('general_scalapacknew')
+      call solve_with_general_scalapacknew(n, proc, matrix_A, eigenpairs, matrix_B)
     case ('general_scalapack_select')
       call setup_distributed_matrix('A', proc, n, n, desc_A, matrix_A_dist)
       call setup_distributed_matrix('B', proc, n, n, desc_B, matrix_B_dist)


### PR DESCRIPTION
Add a new solver called `general_scalapacknew`, which uses PDSYNGST for GEP-to-SEP reduction.
README is also fixed accordingly.