### PR TITLE
[WIP] Add new solver based on PDSYNGST and eigensx

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Names of available solvers are listed below. `general_scalapack` and `general_el
 - eigensx (standard)
 - general_scalapack_eigensx (generalized) -- reduction with PDPOTRF & PDSYGST, solve SEP with eigen_sx; The solver 'B' in our papers [1,2]
 - general_scalapack_eigens (generalized) -- reduction with PDPOTRF & PDSYGST, solve SEP with eigen_s
-- general_scalapacknew_eigens (generalized) -- reduction with PDPOTRF & PDSYNGST
+- general_scalapacknew_eigensx (generalized) -- reduction with PDPOTRF & PDSYNGST, solve SEP with eigen_sx
+- general_scalapacknew_eigens (generalized) -- reduction with PDPOTRF & PDSYNGST, solve SEP with eigen_s
 
 ### solvers need both of ELPA and EigenExa
 - general_elpa_eigensx (generalized) -- reduction with ELPA, solve SEP with eigen_sx; The solver 'G' in our papers [1,2]

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ EigenKernel_App requires input matrix data in [the MatrixMarket file format](htt
 
 ## Quick start
 You can build EigenKernel_App only with ScaLAPACK (without ELPA and EigenExa).
-Test following commands to solve a generalized eigenvalue problem with the matrix size of M = 30. The sample Makefile.in supposes there are mpif90 over gfortran as a fortran compiler and libgomp as an OpenMP library.
+Test following commands to solve a generalized eigenvalue problem with the matrix size of M = 30. The sample Makefile.inc supposes there are mpif90 over gfortran as a fortran compiler and libgomp as an OpenMP library.
 
     tar zxvf eigenkernel-*.tar.gz
     cd eigenkernel-*
-    cp Makefile.in.gfortran.noext Makefile.in
+    cp Makefile.inc.gfortran.noext Makefile.inc
     make
 
 The mini-application appears as bin/eigenkernel_app. You can run the application, for example, as
@@ -44,10 +44,10 @@ You must build and link ELPA and EigenExa to utilize full functions of EigenKern
 
 [EigenExa official page](http://www.aics.riken.jp/labs/lpnctrt/en/projects/eigenexa/)
 
-After installing them, edit Makefile.in (sample found in Makefile.in.gfortran.withext) and set `LIBS` variable properly to indicate the paths where .a and .mod are installed.
+After installing them, edit Makefile.inc (sample found in Makefile.inc.gfortran.withext) and set `LIBS` variable properly to indicate the paths where .a and .mod are installed.
 Then you should rebuild EigenKernel_App with ELPA and EigenExa like below.
 
-    emacs Makefile.in  # Edit $LIBS properly
+    emacs Makefile.inc  # Edit $LIBS properly
     make clean
     make WITH_EIGENEXA=1 WITH_ELPA=1
 

--- a/src/command_argument.f90
+++ b/src/command_argument.f90
@@ -65,6 +65,7 @@ contains
       print *, '  general_elpa2 (generalized)'
       print *, '  general_elpa_eigensx (generalized)'
       print *, '  general_elpa_eigens (generalized)'
+      print *, '  general_scalapacknew_eigensx (generalized)'
       print *, '  general_scalapacknew_eigens (generalized)'
       print *, 'Options are:'
       print *, '  -n <num>  (available with selecting solvers) Compute only &
@@ -165,6 +166,8 @@ contains
     case ('general_elpa_eigensx')
       is_solver_valid = arg%is_generalized_problem
     case ('general_elpa_eigens')
+      is_solver_valid = arg%is_generalized_problem
+    case ('general_scalapacknew_eigensx')
       is_solver_valid = arg%is_generalized_problem
     case ('general_scalapacknew_eigens')
       is_solver_valid = arg%is_generalized_problem

--- a/src/solver_eigenexa.f90
+++ b/src/solver_eigenexa.f90
@@ -17,7 +17,7 @@ module ek_solver_eigenexa_m
   private
   public :: setup_distributed_matrix_for_eigenexa, eigen_solver_eigenexa, eigen_solver_eigenk, &
        solve_with_general_scalapack_eigenexa, solve_with_general_scalapack_eigenk, &
-       solve_with_general_scalapacknew_eigenk
+       solve_with_general_scalapacknew_eigenexa, solve_with_general_scalapacknew_eigenk
 
 contains
 
@@ -364,6 +364,82 @@ contains
     call add_event('solve_with_general_scalapack_eigenk:recovery_generalized', time_end - time_start_part)
     call add_event('solve_with_general_scalapack_eigenk', time_end - time_start)
   end subroutine solve_with_general_scalapack_eigenk
+
+
+  subroutine solve_with_general_scalapacknew_eigenexa(n, proc, matrix_A, eigenpairs, matrix_B)
+    integer, intent(in) :: n
+    type(ek_process_t), intent(in) :: proc
+    type(ek_sparse_mat_t), intent(in) :: matrix_A
+    type(ek_sparse_mat_t), intent(in) :: matrix_B
+    type(ek_eigenpairs_types_union_t), intent(out) :: eigenpairs
+
+    integer :: desc_A(desc_size), desc_B(desc_size), desc_A_re(desc_size), ierr
+    double precision, allocatable :: matrix_A_dist(:, :), matrix_B_dist(:, :), matrix_A_redist(:, :)
+    type(ek_eigenpairs_types_union_t) :: eigenpairs_tmp
+    double precision :: time_start, time_start_part, time_end
+
+    time_start = mpi_wtime()
+    time_start_part = time_start
+
+    call setup_distributed_matrix('A', proc, n, n, desc_A, matrix_A_dist)
+    call setup_distributed_matrix('B', proc, n, n, desc_B, matrix_B_dist)
+    call setup_distributed_matrix_for_eigenexa(n, desc_A_re, matrix_A_redist, eigenpairs_tmp)
+    call distribute_global_sparse_matrix(matrix_A, desc_A, matrix_A_dist)
+    call distribute_global_sparse_matrix(matrix_B, desc_B, matrix_B_dist)
+
+    time_end = mpi_wtime()
+    call add_event('solve_with_general_scalapacknew_eigenexa:setup_matrices', time_end - time_start_part)
+    time_start_part = time_end
+
+    call reduce_generalized_new(n, matrix_A_dist, desc_A, matrix_B_dist, desc_B)
+
+    time_end = mpi_wtime()
+    call add_event('solve_with_general_scalapacknew_eigenexa:reduce_generalized_new', time_end - time_start_part)
+    time_start_part = time_end
+
+    call pdgemr2d(n, n, matrix_A_dist, 1, 1, desc_A, matrix_A_redist, 1, 1, desc_A_re, desc_A(context_))
+    deallocate(matrix_A_dist)
+
+    time_end = mpi_wtime()
+    call add_event('solve_with_general_scalapacknew_eigenexa:pdgemr2d_1', time_end - time_start_part)
+    time_start_part = time_end
+
+    call eigen_solver_eigenexa(matrix_A_redist, desc_A_re, n, eigenpairs_tmp, 'L')
+
+    time_end = mpi_wtime()
+    call add_event('solve_with_general_scalapacknew_eigenexa:eigen_solver_eigenexa', time_end - time_start_part)
+    time_start_part = time_end
+
+    deallocate(matrix_A_redist)
+    eigenpairs%type_number = 2
+    allocate(eigenpairs%blacs%values(n), stat = ierr)
+    if (ierr /= 0) then
+      call terminate('solve_with_general_scalapacknew_eigenexa: allocation failed', ierr)
+    end if
+    eigenpairs%blacs%values(:) = eigenpairs_tmp%blacs%values(:)
+    eigenpairs%blacs%desc(:) = eigenpairs_tmp%blacs%desc(:)
+    call setup_distributed_matrix('Eigenvectors', proc, n, n, &
+         eigenpairs%blacs%desc, eigenpairs%blacs%Vectors, desc_A(block_row_))
+
+    time_end = mpi_wtime()
+    call add_event('solve_with_general_scalapacknew_eigenexa:setup_EV', time_end - time_start_part)
+    time_start_part = time_end
+
+    call pdgemr2d(n, n, eigenpairs_tmp%blacs%Vectors, 1, 1, eigenpairs_tmp%blacs%desc, &
+         eigenpairs%blacs%Vectors, 1, 1, eigenpairs%blacs%desc, &
+         eigenpairs_tmp%blacs%desc(context_))
+
+    time_end = mpi_wtime()
+    call add_event('solve_with_general_scalapacknew_eigenexa:pdgemr2d_2', time_end - time_start_part)
+    time_start_part = time_end
+
+    call recovery_generalized(n, n, matrix_B_dist, desc_B, &
+         eigenpairs%blacs%Vectors, eigenpairs%blacs%desc)
+
+    time_end = mpi_wtime()
+    call add_event('solve_with_general_scalapacknew_eigenexa:recovery_generalized', time_end - time_start_part)
+    call add_event('solve_with_general_scalapacknew_eigenexa', time_end - time_start)
+  end subroutine solve_with_general_scalapacknew_eigenexa
 
 
   subroutine solve_with_general_scalapacknew_eigenk(n, proc, matrix_A, eigenpairs, matrix_B)

--- a/src/solver_eigenexa_dummy.f90
+++ b/src/solver_eigenexa_dummy.f90
@@ -9,7 +9,7 @@ module ek_solver_eigenexa_m
   private
   public :: setup_distributed_matrix_for_eigenexa, eigen_solver_eigenexa, eigen_solver_eigenk, &
        solve_with_general_scalapack_eigenexa, solve_with_general_scalapack_eigenk, &
-       solve_with_general_scalapacknew_eigenk
+       solve_with_general_scalapacknew_eigenexa, solve_with_general_scalapacknew_eigenk
 
 contains
 
@@ -63,6 +63,17 @@ contains
 
     call terminate('solve_with_general_scalapack_eigenk: EigenExa is not supported in this build', 1)
   end subroutine solve_with_general_scalapack_eigenk
+
+
+  subroutine solve_with_general_scalapacknew_eigenexa(n, proc, matrix_A, eigenpairs, matrix_B)
+    integer, intent(in) :: n
+    type(ek_process_t), intent(in) :: proc
+    type(ek_sparse_mat_t), intent(in) :: matrix_A
+    type(ek_sparse_mat_t), intent(in) :: matrix_B
+    type(ek_eigenpairs_types_union_t), intent(out) :: eigenpairs
+
+    call terminate('solve_with_general_scalapacknew_eigenexa: EigenExa is not supported in this build', 1)
+  end subroutine solve_with_general_scalapacknew_eigenexa
 
 
   subroutine solve_with_general_scalapacknew_eigenk(n, proc, matrix_A, eigenpairs, matrix_B)

--- a/src/solver_main.f90
+++ b/src/solver_main.f90
@@ -26,7 +26,7 @@ contains
     use ek_solver_eigenexa_m, only : setup_distributed_matrix_for_eigenexa, &
          eigen_solver_eigenexa, eigen_solver_eigenk, &
          solve_with_general_scalapack_eigenexa, solve_with_general_scalapack_eigenk, &
-         solve_with_general_scalapacknew_eigenk
+         solve_with_general_scalapacknew_eigenexa, solve_with_general_scalapacknew_eigenk
     use ek_solver_elpa_m
     use ek_solver_elpa_eigenexa_m
 
@@ -94,6 +94,8 @@ contains
       call solve_with_general_elpa_eigenexa(n, proc, matrix_A, eigenpairs, matrix_B)
     case ('general_elpa_eigens')
       call solve_with_general_elpa_eigenk(n, proc, matrix_A, eigenpairs, matrix_B)
+    case ('general_scalapacknew_eigensx')
+      call solve_with_general_scalapacknew_eigenexa(n, proc, matrix_A, eigenpairs, matrix_B)
     case ('general_scalapacknew_eigens')
       call solve_with_general_scalapacknew_eigenk(n, proc, matrix_A, eigenpairs, matrix_B)
     case default


### PR DESCRIPTION
The current WIP code fails on my local environment like:
```
[eigenkernel]$ mpirun -np 1 bin/eigenkernel_app -s general_scalapack_eigensx -l time.dat -c -1 matrix/ELSES_MATRIX_BNZ30_A.mtx matrix/ELSES_MATRIX_BNZ30_B.mtx
---------- Eigen Test start ----------
----- Configurations -----
problem type: generalized
(...)
[Event        0.014011] eigen_solver_eigenexa:transpose, 0.3290176391601562E-004

Program received signal SIGSEGV: Segmentation fault - invalid memory reference.

Backtrace for this error:
#0  0x7FC0530D0E08
#1  0x7FC0530CFF90
#2  0x7FC0528014AF
#3  0x421292 in eigen_sx_
#4  0x40B090 in __ek_solver_eigenexa_m_MOD_eigen_solver_eigenexa
#5  0x40D5F3 in __ek_solver_eigenexa_m_MOD_solve_with_general_scalapack_eigenexa
#6  0x405206 in __ek_solver_main_m_MOD_eigen_solver
#7  0x404002 in MAIN__ at main.f90:?
--------------------------------------------------------------------------
mpirun noticed that process rank 0 with PID 4401 on node Deibotsu exited on signal 11 (Segmentation fault).
--------------------------------------------------------------------------
```